### PR TITLE
Update event header description

### DIFF
--- a/2016-london/index.html
+++ b/2016-london/index.html
@@ -208,8 +208,8 @@
     <!-- <script src="../schedule.js"></script> -->
     <script>
       var customConfig = {
-        mainHeaderText: "Mozilla Foundation London All-hands",
-        subHeaderText: "filled with dummy data... for now ;)",
+        mainHeaderText: "London 2016",
+        subHeaderText: "Mozilla Foundation All Hands",
         displayNameForCategory: {
           singular:'all-hand', // this can only be one word
           plural: 'all-hands' // this can only be one word


### PR DESCRIPTION
Adding new descriptions. The hierarchy of the name, brand, info is a bit off, but this will work for now. Later, we should look at Ricardo's proposed redesign of the header and figure out if we want to implement it before or after London.
